### PR TITLE
Curious about rewriting `mapAcc` with `List.foldl`

### DIFF
--- a/FastList.elm
+++ b/FastList.elm
@@ -168,13 +168,7 @@ mapUnrolled12 f xs =
 mapTailRec : (a -> b) -> List a -> List b
 mapTailRec f xs =
     let
-        mapAcc f acc ys =
-            case ys of
-                [] ->
-                    acc
-
-                hd :: tl ->
-                    mapAcc f (f hd :: acc) tl
+        mapAcc f = List.foldl (\hd acc -> f hd :: acc)
     in
         mapAcc f [] xs |> reverse
 


### PR DESCRIPTION
I'd be curious about how your graph for `mapFast` would look like with this change, because other current implementations in `core/List.elm` do use `List.foldl`, e.g., 

``` elm
length : List a -> Int
length xs =
  foldl (\_ i -> i + 1) 0 xs
```

rather than having an explicit recursion there.

No pressure, though.
